### PR TITLE
Weight loss record improvements

### DIFF
--- a/app/controllers/weight_records_controller.rb
+++ b/app/controllers/weight_records_controller.rb
@@ -20,6 +20,25 @@ class WeightRecordsController < ApplicationController
     end
   end
 
+  def edit
+    @weight_record = competition.weight_records.find(params[:id])
+  end
+
+  def update
+    @weight_record = competition.weight_records.find(params[:id])
+    respond_to do |format|
+      if @weight_record.update(weight_record_params)
+        format.html { redirect_to(competition,
+          :notice => 'Weight Record was successfully updated!.') }
+        format.xml { head :ok }
+      else
+        format.html {render :action => "edit" }
+        format.xml { render :xml => @weight_record.errors,
+                      :status => :unprocessessable_entity }
+      end
+    end
+  end
+
   private
 
   def competition

--- a/app/controllers/weight_records_controller.rb
+++ b/app/controllers/weight_records_controller.rb
@@ -39,6 +39,12 @@ class WeightRecordsController < ApplicationController
     end
   end
 
+  def destroy
+    competition.weight_records.find(params[:id]).destroy
+    flash[:notice] = "Record deleted"
+    redirect_to competition_path(competition)
+  end
+
   private
 
   def competition

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -56,6 +56,7 @@
             <th data-field="date" data-sortable="true" >Date</th>
             <th data-field="name">Competitor</th>
             <th data-field="weight">Weight</th>
+            <th data-field="action">Action</th>
           </tr>
         </thead>
         <tbody>
@@ -64,6 +65,13 @@
               <td><%= record.effective_date %></td>
               <td><%= record.user.name %></td>
               <td><%= record.weight %></td>
+              <% wr = record.id %>
+              <% puts wr%>
+              <% if record.user_id == current_user.id %>
+                <td><%= link_to 'Edit', edit_competition_weight_record_path(@competition.id, record.id), class: "btn btn-success btn-sm" %>
+              <% else %>
+                <td></td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -69,6 +69,7 @@
               <% puts wr%>
               <% if record.user_id == current_user.id %>
                 <td><%= link_to 'Edit', edit_competition_weight_record_path(@competition.id, record.id), class: "btn btn-success btn-sm" %>
+                <%= link_to 'Delete', competition_weight_record_path(@competition.id, record.id), data: { confirm: "Are you sure?" }, :method => :delete, class: "btn btn-danger btn-sm" %></td>
               <% else %>
                 <td></td>
               <% end %>

--- a/app/views/weight_records/edit.html.haml
+++ b/app/views/weight_records/edit.html.haml
@@ -1,0 +1,11 @@
+.container
+  %h2.title Edit Weight Record for #{@competition.title}
+
+  = form_with model: [:competition, @weight_record], url: competition_weight_record_path(@competition.id, @weight_record.id) do |f|
+    = f.label :weight, class: "form-label"
+    = f.number_field :weight, class: "form-control", step: 0.1
+    = f.label :effective_date, class: "form-label"
+    = f.date_field :effective_date, class: "form-control"
+
+    = f.submit 'Edit Weight Record', class: "btn btn-success"
+    = link_to 'Cancel', @competition, class: "btn btn-danger"

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module Loseit
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Brisbane"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
Add general improvements to weight loss records, including setting the correct timezone for `effective_date` adn adding ability to edit or delete weight records. A user can only edit or delete their own weight records.