### PR TITLE
Weight record edit authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem 'haml-rails'
 
 gem "chartkick"
 
+gem 'pundit'
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,8 @@ GEM
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
+    pundit (2.3.0)
+      activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.3.1)
     rack-test (1.1.0)
@@ -319,6 +321,7 @@ DEPENDENCIES
   jquery-rails
   pg (~> 1.1)
   puma (~> 5.0)
+  pundit
   rails (~> 7.0.3)
   rspec-rails
   sass-rails (>= 3.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+
+  include Pundit
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  private
+
+    def user_not_authorized
+      flash[:alert] = "You are not authorized to access this page."
+      redirect_to(request.referrer || root_path)
+    end
 end

--- a/app/controllers/weight_records_controller.rb
+++ b/app/controllers/weight_records_controller.rb
@@ -44,7 +44,9 @@ class WeightRecordsController < ApplicationController
   end
 
   def destroy
-    competition.weight_records.find(params[:id]).destroy
+    @weight_record = competition.weight_records.find(params[:id])
+    authorize @weight_record
+    @weight_record.destroy
     flash[:notice] = "Record deleted"
     redirect_to competition_path(competition)
   end

--- a/app/controllers/weight_records_controller.rb
+++ b/app/controllers/weight_records_controller.rb
@@ -22,10 +22,14 @@ class WeightRecordsController < ApplicationController
 
   def edit
     @weight_record = competition.weight_records.find(params[:id])
+    authorize @weight_record
   end
 
   def update
     @weight_record = competition.weight_records.find(params[:id])
+
+    authorize @weight_record
+
     respond_to do |format|
       if @weight_record.update(weight_record_params)
         format.html { redirect_to(competition,

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,0 +1,2 @@
+class AdminUser < User
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,7 @@ class User < ApplicationRecord
   has_many :competitors
   has_many :competitions, through: :competitors
   has_many :weight_records, dependent: :destroy
+
+  validates :name, uniqueness: true, presence: true, format: { with: /\A[a-zA-Z]+([a-zA-Z]|\d)*\Z/ }
+
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NotImplementedError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/weight_record_policy.rb
+++ b/app/policies/weight_record_policy.rb
@@ -1,0 +1,13 @@
+class WeightRecordPolicy < ApplicationPolicy
+  def edit?
+    user_who_can_access_weight_record
+  end
+
+  def update?
+    user_who_can_access_weight_record
+  end
+
+  def user_who_can_access_weight_record
+    record.user_id == user.id
+  end
+end

--- a/app/policies/weight_record_policy.rb
+++ b/app/policies/weight_record_policy.rb
@@ -7,6 +7,10 @@ class WeightRecordPolicy < ApplicationPolicy
     user_who_can_access_weight_record
   end
 
+  def destroy?
+    user_who_can_access_weight_record
+  end
+
   def user_who_can_access_weight_record
     record.user_id == user.id
   end

--- a/db/migrate/20230207213906_add_type_to_users.rb
+++ b/db/migrate/20230207213906_add_type_to_users.rb
@@ -1,0 +1,5 @@
+class AddTypeToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_01_001647) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_07_213906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_01_001647) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "type"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,37 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+AdminUser.create!(
+  email: "admin@test.com",
+  password: "asdfasdf",
+  password_confirmation: "asdfasdf",
+  name: "wallwatcher"
+)
+
+puts "Admin user created"
+
+User.create!(
+  email: "normal@test.com",
+  password: "asdfasdf",
+  password_confirmation: "asdfasdf",
+  name: "normalwallwatcher"
+)
+
+puts "Normal user created"
+
+Competition.create!(
+  title: "Test Comp 1",
+  start_date: Time.zone.now,
+  finish_date: Time.zone.now,
+  created_at: Time.zone.now,
+  updated_at: Time.zone.now
+)
+
+puts "Competition created"
+
+WeightRecord.create!(
+  user_id: (User.find_by(email: "normal@test.com").id),
+  competition_id: (Competition.find_by(title: "Test Comp 1").id),
+  weight: 0.100e3,
+  effective_date: Time.zone.now,
+  created_at: Time.zone.now, updated_at: Time.zone.now
+)
+
+puts "Weight Record created"

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :admin_user do
+    sequence(:name) { |n| "admin#{n}" }
+    sequence(:email) { |n| "admin#{n}@admin.com" }
+    password { '123456' }
+    password_confirmation { '123456' }
+  end
+end

--- a/spec/factories/competition.rb
+++ b/spec/factories/competition.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :competition do
+    sequence(:title) { |n| "Competition #{n}" }
+    start_date { Time.zone.now }
+    finish_date { Time.zone.now }
+    created_at { Time.zone.now }
+    updated_at { Time.zone.now }
+  end
+end

--- a/spec/features/weight_record_spec.rb
+++ b/spec/features/weight_record_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe 'editing' do
+  before do
+    user = FactoryBot.create(:user)
+    second_user = FactoryBot.create(:user)
+    login_as(user, :scope => :user)
+    competition = FactoryBot.create(:competition)
+    weight_record = WeightRecord.create!(
+      user_id: user.id,
+      competition_id: competition.id,
+      weight: 0.100e3,
+      effective_date: Time.zone.now,
+      created_at: Time.zone.now,
+      updated_at: Time.zone.now
+    )
+
+    edit_path = "/competitions/#{competition.id}/weight_records/#{weight_record.id}/edit"
+    competition_id = competition.id
+    visit edit_path
+  end
+
+  it 'allows a user to edit a post they created' do
+    fill_in 'weight_record[weight]', with: 101.00
+
+    click_on "Edit Weight Record"
+
+    expect(page).to have_content(101.00)
+  end
+
+  it 'does not allow a user to edit a post they did not create' do
+    logout(:user)
+    login_as(@second_user, :scope => :user)
+    visit @edit_path
+    expect(current_path).to eq("/login")
+  end
+end
+
+# describe 'deleting' do
+#   before do
+#     user = FactoryBot.create(:user)
+#     second_user = FactoryBot.create(:user)
+#     login_as(user, :scope => :user)
+#     competition = FactoryBot.create(:competition)
+#     weight_record = WeightRecord.create!(
+#       user_id: user.id,
+#       competition_id: competition.id,
+#       weight: 0.100e3,
+#       effective_date: Time.zone.now,
+#       created_at: Time.zone.now,
+#       updated_at: Time.zone.now
+#     )
+
+#     competition_path = "/competitions/#{competition.id}"
+#     competition_id = competition.id
+#     weight_record_id = weight_record.id
+#     visit competition_path
+#   end
+
+#   it 'allows a user to delete a post they created' do
+#     click_on "Delete"
+#     dismiss_confirm do
+#       click_button 'OK'
+#     end
+
+#     expect(current_path).to eq(@competition_path)
+#   end
+
+#   # it 'does not allow a user to edit a post they did not create' do
+#   #   logout(:user)
+#   #   login_as(@second_user, :scope => :user)
+#   #   visit @edit_path
+#   #   expect(current_path).to eq("/login")
+#   # end
+# end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe AdminUser, type: :model do
+  describe 'creation' do
+    before do
+      @admin = FactoryBot.create(:admin_user)
+    end
+
+    it 'can be created' do
+      expect(@admin).to be_valid
+    end
+  end
+end

--- a/spec/models/weight_record_spec.rb
+++ b/spec/models/weight_record_spec.rb
@@ -11,4 +11,40 @@ RSpec.describe WeightRecord, type: :model do
     it { should belong_to(:user) }
     it { should belong_to(:competition) }
   end
+
+  describe 'editing' do
+    before do
+      user = FactoryBot.create(:user)
+      second_user = FactoryBot.create(:user)
+      login_as(user, :scope => :user)
+      competition = FactoryBot.create(:competition)
+      weight_record = WeightRecord.create!(
+        user_id: user.id,
+        competition_id: competition.id,
+        weight: 0.100e3,
+        effective_date: Time.zone.now,
+        created_at: Time.zone.now,
+        updated_at: Time.zone.now
+      )
+
+      edit_path = "/competitions/#{competition.id}/weight_records/#{weight_record.id}/edit"
+      competition_id = competition.id
+      visit edit_path
+    end
+
+    it 'allows a user to edit a post they created' do
+      fill_in 'weight_record[weight]', with: 101.00
+
+      click_on "Edit Weight Record"
+
+      expect(page).to have_content(101.00)
+    end
+
+    it 'does not allow a user to edit a post they did not create' do
+      logout(:user)
+      login_as(@second_user, :scope => :user)
+      visit @edit_path
+      expect(current_path).to eq("/login")
+    end
+  end
 end

--- a/spec/models/weight_record_spec.rb
+++ b/spec/models/weight_record_spec.rb
@@ -11,40 +11,4 @@ RSpec.describe WeightRecord, type: :model do
     it { should belong_to(:user) }
     it { should belong_to(:competition) }
   end
-
-  describe 'editing' do
-    before do
-      user = FactoryBot.create(:user)
-      second_user = FactoryBot.create(:user)
-      login_as(user, :scope => :user)
-      competition = FactoryBot.create(:competition)
-      weight_record = WeightRecord.create!(
-        user_id: user.id,
-        competition_id: competition.id,
-        weight: 0.100e3,
-        effective_date: Time.zone.now,
-        created_at: Time.zone.now,
-        updated_at: Time.zone.now
-      )
-
-      edit_path = "/competitions/#{competition.id}/weight_records/#{weight_record.id}/edit"
-      competition_id = competition.id
-      visit edit_path
-    end
-
-    it 'allows a user to edit a post they created' do
-      fill_in 'weight_record[weight]', with: 101.00
-
-      click_on "Edit Weight Record"
-
-      expect(page).to have_content(101.00)
-    end
-
-    it 'does not allow a user to edit a post they did not create' do
-      logout(:user)
-      login_as(@second_user, :scope => :user)
-      visit @edit_path
-      expect(current_path).to eq("/login")
-    end
-  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,10 @@ require 'rspec/rails'
 
 require 'capybara/rails'
 require 'capybara/rspec'
+include Capybara::DSL
+
+include Warden::Test::Helpers
+Warden.test_mode!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
Add authorization to weight_record edit and delete. This will ensure a user cannot interfere with another user's weigth_records.